### PR TITLE
Added the ability to use "XNUMx,yX" in messages

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import random
+import re
 
 try:
     from hashlib import md5
@@ -43,6 +44,40 @@ class MainHandler(tornado.web.RequestHandler):
 
         message = message.replace('XUPPERNAMEX', random.choice(names).upper())
         message = message.replace('XLOWERNAMEX', random.choice(names).lower())
+
+        num_re = re.compile(r"XNUM([0-9]*),?([0-9]*)X")
+        nums = num_re.findall(message)
+
+        while nums:
+            start, end = nums.pop(0)
+
+            if start and end:
+                #yay, everything was given
+                start, end = map(int, (start, end))
+                start, end = min(start, end), max(start, end)  #silly XNAMEX
+
+                if start == end:
+                    #what the fuck are you even doing
+                    randint = start
+                else:
+                    randint = random.randint(start, end)
+            elif (start and not end) or (end and not start):
+                #only one bound was given
+                #either way, consider it the upper bound
+                num = int(start or end)
+                
+                #edge-case when start or end is 0
+                #this doesn't do negatives though so wtf XNAMEX?
+                randint = 0 if not num else random.randint(1, num)
+            else:
+                #no bounds given, so we assume that the message wants a random
+                #integer between 1 and 999 inclusive. If the message wants
+                #something different, it should specify that!
+                #My logic here is that this is the normal need
+                randint = random.randint(1, 999)
+
+            #only do one replacement, to allow multiple XNUMX's
+            message = num_re.sub(str(randint), message, count=1)
 
         self.output_message(message, message_hash)
 

--- a/commit_messages.txt
+++ b/commit_messages.txt
@@ -1,4 +1,4 @@
-One does not simply merge into master
+﻿One does not simply merge into master
 Merging the merge
 Another bug bites the dust
 de-misunderestimating
@@ -111,7 +111,7 @@ Fixed a bug cause XNAMEX said to
 Use a real JS construct, WTF knows why this works in chromium.
 Added a banner to the default admin page. Please have mercy on me =(
 needs more cow bell
-Switched off unit test X because the build had to go out now and there was no time to fix it properly.
+Switched off unit test XNUM15X because the build had to go out now and there was no time to fix it properly.
 Updated
 I must sleep... it's working... in just three hours...
 I was wrong...
@@ -386,7 +386,7 @@ Code was clean until manager requested to fuck it up
 :(:(
 ...
 GIT :/
-stopped caring 10 commits ago
+stopped caring XNUM8,23X commits ago
 Testing in progress ;)
 Fixed Bug
 Fixed errors
@@ -412,6 +412,9 @@ I should get a raise for this.
 Done, to whoever merges this, good luck.
 Not one conflict, today was a good day.
 First Blood
-Fixed the fuck out of #526!
+Fixed the fuck out of #XNUMX!
 I'm too old for this shit!
 One little whitespace gets its very own commit! Oh, life is so erratic!
+It only compiles every XNUM2,5X tries... good luck.
+This will definitely break in 20XNUM20,89X (TODO)
+Issue #XNUM10X is now Issue #XNUM30X

--- a/testing.py
+++ b/testing.py
@@ -1,0 +1,52 @@
+import random
+import re
+
+messages = open("commit_messages.txt").read().split('\n')
+
+names = ['Nick', 'Steve', 'Andy', 'Qi', 'Fanny', 'Sarah', 'Cord', 'Todd',
+    'Chris', 'Pasha', 'Gabe', 'Tony', 'Jason', 'Randal', 'Ali', 'Kim',
+    'Rainer', 'Guillaume', 'Kelan', 'David', 'John', 'Stephen', 'Tom', 'Steven',
+    'Jen', 'Marcus', 'Edy', 'Rachel']
+
+def get(message=None):
+    message = message or random.choice(messages)
+
+    message = message.replace('XNAMEX', random.choice(names))
+    message = message.replace('XUPPERNAMEX', random.choice(names).upper())
+    message = message.replace('XLOWERNAMEX', random.choice(names).lower())
+    
+    num_re = re.compile(r"XNUM([0-9]*),?([0-9]*)X")
+    nums = num_re.findall(message)
+
+    while nums:
+        start, end = nums.pop(0)
+
+        if start and end:
+            #yay, everything was given
+            start, end = map(int, (start, end))
+            start, end = min(start, end), max(start, end)  #silly XNAMEX
+
+            if start == end:
+                #what the fuck are you even doing
+                randint = start
+            else:
+                randint = random.randint(start, end)
+        elif (start and not end) or (end and not start):
+            #only one bound was given
+            #either way, consider it the upper bound
+            num = int(start or end)
+            
+            #edge-case when start or end is 0
+            #this doesn't do negatives though so wtf XNAMEX?
+            randint = 0 if not num else random.randint(1, num)
+        else:
+            #no bounds given, so we assume that the message wants a random
+            #integer between 1 and 999 inclusive. If the message wants
+            #something different, it should specify that!
+            #My logic here is that this is the normal need
+            randint = random.randint(1, 999)
+
+        #only do one replacement, to allow multiple XNUMX's
+        message = num_re.sub(str(randint), message, count=1)
+
+    return message


### PR DESCRIPTION
- "XNUMx,yX" can be used as a proxy for random.randint (sort of - see
code) in commit messages
- heavily commented to explain my thoughts as I went through, happy to
get rid of those and put them into this format instead
- also included `testing.py`, which is a stripped down standalone
version of `MainHandler.get`, which I used (unsurprisingly) for testing
purposes. I provide this so that you can try to break my code. I think
I've dealt with every edge case, but everyone thinks that incorrectly at
some point

- I've modified a couple of the commit message that already had numbers
to now have slightly random numbers. I've also added a few at the bottom
to showcase the brand new feature
- also supports multiple instances of "XNUMx,yX" in a single message,
each giving a random number