### PR TITLE
Can now deterministically choose message based on MD5 hash

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -77,7 +77,11 @@ class MainHandler(tornado.web.RequestHandler):
         if not message_hash:
             message_hash = random.choice(messages.keys())
         elif message_hash not in messages:
-            raise tornado.web.HTTPError(404)
+            try:
+                random.seed(int(message_hash, 16))
+                message_hash = random.choice(messages.keys())
+            except:
+                raise tornado.web.HTTPError(404)
 
         message = fill_line(messages[message_hash])
 
@@ -102,9 +106,9 @@ settings = {
 
 application = tornado.web.Application([
     (r'/', MainHandler),
-    (r'/([a-z0-9]+)', MainHandler),
+    (r'/([a-f0-9]{32})', MainHandler),
     (r'/index.txt', PlainTextHandler),
-    (r'/([a-z0-9]+)/index.txt', PlainTextHandler),
+    (r'/([a-f0-9]{32})/index.txt', PlainTextHandler),
     (r'/humans.txt', HumansHandler),
 ], **settings)
 

--- a/commit.py
+++ b/commit.py
@@ -74,19 +74,22 @@ def fill_line(message):
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self, message_hash=None):
+        message = ''
         if not message_hash:
             message_hash = random.choice(messages.keys())
+            message = fill_line(messages[message_hash])
         elif message_hash not in messages:
             state = random.getstate()
             try:
-                random.seed(int(message_hash, 16))
+                random.seed(message_hash)
                 message_hash = random.choice(messages.keys())
+                message = fill_line(messages[message_hash])  # use seed value for random selection
             except:
                 raise tornado.web.HTTPError(404)
             finally:
                 random.setstate(state)
-
-        message = fill_line(messages[message_hash])
+        else:
+            message = fill_line(messages[message_hash])
 
         self.output_message(message, message_hash)
 

--- a/commit.py
+++ b/commit.py
@@ -77,11 +77,14 @@ class MainHandler(tornado.web.RequestHandler):
         if not message_hash:
             message_hash = random.choice(messages.keys())
         elif message_hash not in messages:
+            state = random.getstate()
             try:
                 random.seed(int(message_hash, 16))
                 message_hash = random.choice(messages.keys())
             except:
                 raise tornado.web.HTTPError(404)
+            finally:
+                random.setstate(state)
 
         message = fill_line(messages[message_hash])
 


### PR DESCRIPTION
Resolves issue #108. 

I adjusted the routing patterns to only allow 32-character hexadecimal strings (as md5sum produces)

When a string is given that is in the keys, it is used directly. All existing permalinks should therefore remain pointing to the same content.

When a string is given that is not in the keys, it is used as an argument to `random.seed()` before choosing a message with `random.choice()`.

Random state is stashed before seeding and restored afterward to prevent trolls from while true; do curl ...; done on a specific hash to keep it locked at more-or-less one message.
