### PR TITLE
Python 3.5.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+### JetBrains modified    =~=~=~=~=~=~=~=~=~=~=~=
+# Covers JetBrains IDEs
+
+*.iml
+
+## Directory-based project format:
+.idea/
+
+## File-based project format:
+*.ipr
+*.iws
+
+# Created by .ignore support plugin (hsz.mobi)
+###                       =~=~=~=~=~=~=~=~=~=~=~=

--- a/commit.py
+++ b/commit.py
@@ -28,7 +28,7 @@ messages = {}
 # Create a hash table of all commit messages
 with open(messages_file) as messages_input:
     for line in messages_input.readlines():
-        messages[md5(line).hexdigest()] = line
+        messages[md5(line.encode()).hexdigest()] = line
 
 with open(humans_file) as humans_input:
     humans_content = humans_input.read()
@@ -75,7 +75,7 @@ def fill_line(message):
 class MainHandler(tornado.web.RequestHandler):
     def get(self, message_hash=None):
         if not message_hash:
-            message_hash = random.choice(messages.keys())
+            message_hash = random.choice(list(messages.keys()))
         elif message_hash not in messages:
             raise tornado.web.HTTPError(404)
 

--- a/commit_messages.txt
+++ b/commit_messages.txt
@@ -49,7 +49,7 @@ forgot we're not using a smart language
 include shit
 To those I leave behind, good luck!
 things occurred
-i dunno, maybe this works
+I dunno, maybe this works
 8==========D
 No changes made
 whooooooooooooooooooooooooooo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Tornado==4.2.0
+Tornado>=4.2.0

--- a/testing.py
+++ b/testing.py
@@ -22,7 +22,7 @@ for line in open(humans_file).readlines():
         else:
             names.append(data.split(" ")[0])
 
-print "names", names
+print("names", names)
 
 num_re = re.compile(r"XNUM([0-9,]*)X")
 
@@ -60,4 +60,4 @@ def get(message=None):
     return fill_line(message or random.choice(messages))
 
 if __name__ == '__main__':
-    print get(sys.argv[1] or None)
+    print(get(sys.argv[1]if len(sys.argv) > 1 else None))


### PR DESCRIPTION
Created version running with python 3.5.1 (v3.5.1:37a07cee5969, Dec  6
2015, 01:54:25) [MSC v.1900 64 bit (AMD64)] on win32
- including .gitignore for JetBrains PyCharm

I dunno, maybe this works in python 2.x, maybe not...