### PR TITLE
Removing political/partisan messages which may be offensive

### DIFF
--- a/commit_messages.txt
+++ b/commit_messages.txt
@@ -2,7 +2,6 @@
  ¯\_(ツ)_/¯
 "Get that shit outta my master."
 #GrammarNazi
-#elesim
 $(init 0)
 $(rm -rvf .)
 (\ /)<br/>(O.o)<br/>(&gt; &lt;) Bunny approves these changes.
@@ -41,7 +40,6 @@ Become a programmer, they said. It'll be fun, they said.
 Best commit ever
 Bit Bucket is down. What should I do now?
 Blaming regex.
-Bolsonaro 2018
 By works, I meant 'doesnt work'.  Works now..
 Can someone review this commit, please ?
 COMMIT ALL THE FILES!

--- a/static/humans.txt
+++ b/static/humans.txt
@@ -80,6 +80,7 @@ Name: Ahmad Samiei (github:amad)
 Name: Shaun Hammill (github:Plloi)
 Name: github:KneeNinetySeven
 Name: Rafael Reis (github:reisraff)
+Name: Jonatha Daguerre (github:jonathadv)
 
 /* SITE */
 Last update: 2014/04/17


### PR DESCRIPTION
This PR removes two messages added in https://github.com/ngerakines/commitment/commit/a5ead3b901f649855247d63aa925c79e3e613645 which are strict related to the Brazil general elections 2018 and give support to one of the candidates, well know as a hard-right, homophobic and "nostalgic for the generals and torturers who ran Brazil for 20 years", as can be seen in these [nytimes](https://www.nytimes.com/2018/10/21/opinion/brazil-election-jair-bolsonaro.html) and [theguardian](https://www.theguardian.com/world/2018/oct/28/jair-bolsonaro-wins-brazil-presidential-election) articles.

I believe this project aims to be something fun to everyone, and not a way to impose political/partisan opinions or beliefs which may be offensive to some person. 

This is Github, a place to share knowledge, help and respect to the others.

Technical points to remove those messages:
 * They are not related at all to the software development context.
 * They are not fun.
 * They only make sense on the Brazil general elections 2018 context.