### PR TITLE
[DOCS] Update URL protocol in cURL example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,18 +1,18 @@
 # Looking For Sponsors
 
-Enjoying http://whatthecommit.com/ ? Consider becoming a sponsor of this project. Your contributions keep the site running.
+Enjoying https://whatthecommit.com/ ? Consider becoming a sponsor of this project. Your contributions keep the site running.
 
 https://github.com/users/ngerakines/sponsorship
 
 # About WTC (What The Commit)
 Commitment is a small Tornado application that generates random commit messages.
 
-    http://whatthecommit.com/
+    https://whatthecommit.com/
 
-Commitment also provides http://whatthecommit.com/index.txt which provides plain text output.  
+Commitment also provides https://whatthecommit.com/index.txt which provides plain text output.  
 Some interesting usage for that can be:
 ```
-git config --global alias.yolo '!git commit -m "$(curl -s whatthecommit.com/index.txt)"'
+git config --global alias.yolo '!git commit -m "$(curl -s https://whatthecommit.com/index.txt)"'
 ```
 
 Or use the [WhatTheCommit](https://marketplace.visualstudio.com/items?itemName=Gaardsholt.vscode-whatthecommit) vscode extension


### PR DESCRIPTION
I don't remember when it changed, but `curl -s whatthecommit.com` stopped working correctly, when `whatthecommit.com` started to redirect to `https:`.

Running `curl -s whatthecommit.com` currently results in:

```bash
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
</body>
</html>
```

Don't get me wrong. This is a perfect fit for WTC. However, getting the same message over and over got a bit boring.

That is why I suggest you update the example in `README.markdown`. Consequently, I'm prosing to update the protocol throughout the entire README.